### PR TITLE
Storing default settings for 'Show passed koan' and 'Look ahead'

### DIFF
--- a/lib/jasmine/coffeekoans-jasmine-html.js
+++ b/lib/jasmine/coffeekoans-jasmine-html.js
@@ -1,3 +1,4 @@
+
 CoffeeKoansReporter = function(doc) {
   this.document = doc || document;
   this.suiteDivs = {};
@@ -31,8 +32,21 @@ CoffeeKoansReporter.prototype.createDom = function(type, attrs, childrenVarArgs)
   return el;
 };
 
+CoffeeKoansReporter.prototype.createCheckboxDomWithDefaultValue = function (id) {
+    var attrs = { id: id, type: 'checkbox' };
+    if (localStorage.getItem(id+"_defaultValue")) {
+        attrs.checked = 'true';
+    }
+    return this.createDom('input', attrs);
+};
+
+CoffeeKoansReporter.prototype.setCheckboxDefaultValue = function (id, value) {
+    localStorage.setItem(id+"_defaultValue", value);
+};
+
+
 CoffeeKoansReporter.prototype.reportRunnerStarting = function(runner) {
-  this.outerDiv = this.createDom('div', { className: 'jasmine_reporter show-passed' },
+  this.outerDiv = this.createDom('div', { className: 'jasmine_reporter' },
       this.createDom('h1', { }, "CoffeeScript Koans"),
       this.runnerDiv = this.createDom('div', { className: 'runner running' },
         this.runnerMessageSpan = this.createDom('span', { classname: 'running' }, "Contemplating naval..."),
@@ -93,8 +107,8 @@ CoffeeKoansReporter.prototype.reportRunnerResults = function(runner) {
   var specsCount = runner.specs().length;
   var showPassed;
   var showAllFailed;
-  
-  var progress = this.createDom('div', {}, 
+
+  var progress = this.createDom('div', {},
       this.createDom('div', { className: 'enlightenment-' + status }, enlightenmentMessage),
       this.createDom('div', { className: 'completion' }, 
         this.createDom('div', {},
@@ -107,29 +121,38 @@ CoffeeKoansReporter.prototype.reportRunnerResults = function(runner) {
           ),
         this.createDom('div', { className: 'options' },
           this.createDom('label', { "for": "__coffeeKoans_showPassed__" }, " Show passed koans"),
-          showPassed = this.createDom('input', { id: "__coffeeKoans_showPassed__", type: 'checkbox', checked: '' }),
+          showPassed = this.createCheckboxDomWithDefaultValue("__coffeeKoans_showPassed__"),
           this.createDom('label', { "for": "__coffeeKoans_showAllFailed__" }, " Look ahead"),
-          showAllFailed = this.createDom('input', { id: "__coffeeKoans_showAllFailed__", type: 'checkbox' })
+          showAllFailed = this.createCheckboxDomWithDefaultValue("__coffeeKoans_showAllFailed__")
           )
         )      
       );
   this.runnerMessageSpan.replaceChild(this.createDom('div', { className: 'description', href: '?'}, progress), this.runnerMessageSpan.firstChild);
   
   var self = this;
+
+  var toggleClassAndStoreDefault = function(className, evt) {
+      if (evt.target.checked) {
+          self.outerDiv.className += ' ' + className;
+          self.setCheckboxDefaultValue(evt.target.id,true);
+      } else {
+          self.outerDiv.className = self.outerDiv.className.replace(" " + className, '');
+          self.setCheckboxDefaultValue(evt.target.id,'');
+      }
+  };
+
   showPassed.onchange = function(evt) {
-    if (evt.target.checked) {
-      self.outerDiv.className += ' show-passed';
-    } else {
-      self.outerDiv.className = self.outerDiv.className.replace(/ show-passed/, '');
-    }
+    toggleClassAndStoreDefault("show-passed",evt)
   };
+
   showAllFailed.onchange = function(evt) {
-    if (evt.target.checked) {
-      self.outerDiv.className += ' show-skipped';
-    } else {
-      self.outerDiv.className = self.outerDiv.className.replace(/ show-skipped/, '');
-    }
+    toggleClassAndStoreDefault("show-skipped",evt)
   };
+
+  //making sure view is in a good state when the page loads
+  showPassed.onchange({target: showPassed});
+  showAllFailed.onchange({target: showAllFailed});
+
 };
 
 CoffeeKoansReporter.prototype.reportSuiteResults = function(suite) {


### PR DESCRIPTION
Hi!

My setup: 
- On the screen, side by side browser with KoansRunner.html and IDE.
- watchr koans-mac.watchr

To keep me focused I've set 'Show passed koans" to false. Every time I've made a change in IDE this setting would be lost (while page was reloaded). I've fixed this for myself by storing default value in browser cache.

Best,
Greg
